### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/luminance.cabal
+++ b/luminance.cabal
@@ -116,7 +116,7 @@ library
   build-depends:       base           >= 4.8  && < 4.9
                      , containers     >= 0.5  && < 0.6
                      , contravariant  >= 1.3  && < 1.5
-                     , dlist          >= 0.7  && < 0.8
+                     , dlist          >= 0.7  && < 0.9
                      , gl             >= 0.7  && < 0.8
                      , linear         >= 1.19 && < 1.21
                      , mtl            >= 2.2  && < 2.3


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `luminance`, but I don't think it will be break anything.